### PR TITLE
영어영문학과, 노어노문학과 크롤링

### DIFF
--- a/src/routes/humanities/english.ts
+++ b/src/routes/humanities/english.ts
@@ -1,0 +1,13 @@
+import { GeogCrawler } from '../social/geog';
+import { HUMANITIES } from '../../constants';
+
+export const english = new GeogCrawler({
+    departmentName: '영어영문학과',
+    departmentCode: 'english',
+    departmentCollege: HUMANITIES,
+    baseUrl: 'https://english.snu.ac.kr/category/',
+    categoryTags: {
+        board_10_GN_9Fb7DO6t_20201130130441: '공지사항',
+        board_10_GN_NjxGZJcf_20201130130424: '행사',
+    },
+});

--- a/src/routes/humanities/russian.ts
+++ b/src/routes/humanities/russian.ts
@@ -1,0 +1,15 @@
+import { GeogCrawler } from '../social/geog';
+import { HUMANITIES } from '../../constants';
+
+export const russian = new GeogCrawler({
+    departmentName: '노어노문학과',
+    departmentCode: 'russian',
+    departmentCollege: HUMANITIES,
+    baseUrl: 'https://russian.snu.ac.kr/category/',
+    categoryTags: {
+        board_3_GN_44WyCJtw_20201202131822: '공지사항',
+        'board-31-GN-0Cph9vw0-2021022220360': '장학',
+        'board-31-GN-1306Xk6x-20210222203800': '채용/행사',
+        'board-31-GN-gm2v0p43-20210323172210': '코로나19',
+    },
+});

--- a/src/routes/routeList.ts
+++ b/src/routes/routeList.ts
@@ -59,6 +59,7 @@ import { ethics } from './edu/ethics';
 import { engEdu } from './edu/engedu';
 import { art } from './art/art';
 import { asia } from './humanities/asia';
+import { english } from './humanities/english';
 
 export const crawlerList: Crawler[] = [
     // cse,
@@ -120,5 +121,6 @@ export const crawlerList: Crawler[] = [
     engEdu,
     art,
     asia,
+    english,
 ];
 export const routeList: ((connection: Connection) => Promise<void>)[] = crawlerList.map((cr) => cr.startCrawl);

--- a/src/routes/routeList.ts
+++ b/src/routes/routeList.ts
@@ -60,6 +60,7 @@ import { engEdu } from './edu/engedu';
 import { art } from './art/art';
 import { asia } from './humanities/asia';
 import { english } from './humanities/english';
+import { russian } from './humanities/russian';
 
 export const crawlerList: Crawler[] = [
     // cse,
@@ -122,5 +123,6 @@ export const crawlerList: Crawler[] = [
     art,
     asia,
     english,
+    russian,
 ];
 export const routeList: ((connection: Connection) => Promise<void>)[] = crawlerList.map((cr) => cr.startCrawl);

--- a/src/routes/social/geog.ts
+++ b/src/routes/social/geog.ts
@@ -34,13 +34,7 @@ export class GeogCrawler extends CategoryCrawler {
             notice.department = siteData.department;
 
             // find category in stat.snu.ac.kr & geog.snu.ac.kr
-            const tagTitleString = $('div.board_view_header strong.tit').text().trim();
-            const tagTitle = parseTitle(tagTitleString);
-            if (this.departmentCode === 'stat' && this.categoryTags[boardCategory] !== '취업정보') {
-                notice.title = tagTitle.title;
-            } else {
-                notice.title = tagTitleString;
-            }
+            notice.title = $('div.board_view_header strong.tit').text().trim();
 
             const contentElement = $('div.board_view_content');
             const content = load(contentElement.html() ?? '', { decodeEntities: false })('body').html() ?? '';
@@ -72,12 +66,6 @@ export class GeogCrawler extends CategoryCrawler {
             );
 
             let tags: string[] = [];
-            if (this.departmentCode === 'stat') {
-                tagTitle.tags = tagTitle.tags.flatMap((tag) => tag.split('/')).map((tag) => tag.trim());
-                tagTitle.tags.forEach((tag) => {
-                    tags.push(tag);
-                });
-            }
 
             // find category in geog.snu.ac.kr and communication.snu.ac.kr
             const category = $('em.cate').text().trim();

--- a/src/routes/social/geog.ts
+++ b/src/routes/social/geog.ts
@@ -17,6 +17,7 @@ export class GeogCrawler extends CategoryCrawler {
         const { request, $ } = context;
         const { url } = request;
         const siteData = <SiteData>request.userData;
+        const boardCategory: string = url.split('/')[4];
 
         this.log.info('Page opened.', { url });
 
@@ -33,8 +34,13 @@ export class GeogCrawler extends CategoryCrawler {
             notice.department = siteData.department;
 
             // find category in stat.snu.ac.kr & geog.snu.ac.kr
-            const tagTitle = parseTitle($('div.board_view_header strong.tit').text().trim());
-            notice.title = tagTitle.title;
+            const tagTitleString = $('div.board_view_header strong.tit').text().trim();
+            const tagTitle = parseTitle(tagTitleString);
+            if (this.departmentCode === 'stat' && this.categoryTags[boardCategory] !== '취업정보') {
+                notice.title = tagTitle.title;
+            } else {
+                notice.title = tagTitleString;
+            }
 
             const contentElement = $('div.board_view_content');
             const content = load(contentElement.html() ?? '', { decodeEntities: false })('body').html() ?? '';
@@ -66,10 +72,12 @@ export class GeogCrawler extends CategoryCrawler {
             );
 
             let tags: string[] = [];
-            tagTitle.tags = tagTitle.tags.flatMap((tag) => tag.split('/')).map((tag) => tag.trim());
-            tagTitle.tags.forEach((tag) => {
-                tags.push(tag);
-            });
+            if (this.departmentCode === 'stat') {
+                tagTitle.tags = tagTitle.tags.flatMap((tag) => tag.split('/')).map((tag) => tag.trim());
+                tagTitle.tags.forEach((tag) => {
+                    tags.push(tag);
+                });
+            }
 
             // find category in geog.snu.ac.kr and communication.snu.ac.kr
             const category = $('em.cate').text().trim();
@@ -78,7 +86,6 @@ export class GeogCrawler extends CategoryCrawler {
             }
 
             // geog의 장학 게시판, stat의 취업정보 게시
-            const boardCategory: string = url.split('/')[4];
             if (['장학', '취업정보'].includes(this.categoryTags[boardCategory])) {
                 tags = [];
             }


### PR DESCRIPTION
resolve #187
영어영문학과 공지사항을 크롤링합니다

영어영문학과에 사용되는 지리학과 크롤러를 일부 수정하였습니다
- 통계학과 이외에는 [태그]방식을 사용하지 않아 통계학과가 아닌 경우 + 통계학과의 취업 정보 게시판([태그] 사용 x) 은 제목에서 [태그]제외하지 않도록 수정
- 통계학과의 경우 [태그] 제목의 형태로 되어있긴 하지만, 태그가 몇개로 한정되어 있지 않고, 뜬금없는 태그들이 많아 크롤링을 진행 후에 태그를 추려 그 태그만 되도록 하는 것이 좋아보입니다.
- 하지만 리뉴얼 된지 얼마 되지 않아 태그를 추리는 것이 쉽지는 않아 보입니다. 때문에 공지사항으로 전체 태그를 통일하는 것도 고려해볼만 합니다.

우선 이 PR에서는 통계학과에 한해 [태그] 제목에서 [태그]를 이용해 태그를 만들어 주었습니다
이 부분에 대해서 의견 부탁드립니다