### PR TITLE
윤리교육과 lastNoticeId 버그 픽스

### DIFF
--- a/src/routes/edu/ethics.ts
+++ b/src/routes/edu/ethics.ts
@@ -86,7 +86,7 @@ class EthicsCrawler extends CategoryCrawler {
             const pageString = urlInstance.searchParams.get('page') ?? '1';
             const page: number = +pageString;
 
-            $('table.board_re').each((index, element) => {
+            $('table.board_re, table.board').each((index, element) => {
                 const noticeNum = $(element).find('tr td:nth-child(1)').text().trim();
                 const isPinned = noticeNum === '';
 


### PR DESCRIPTION
notice에 해당하는 css선택자가 board_re와 board 두가지가 있어서 생기는 문제였습니다.

머지되면 윤리교육과의 request_queue를 삭제하고 크롤링할 생각입니다.