### PR TITLE
fix creating duplicate noticeTag

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,9 @@ export async function getOrCreateTags(tags: string[], notice: Notice, department
     await Promise.all(
         tags.map(async (tagName) => {
             const tag = await getOrCreate(Tag, { department, name: tagName });
-            await getOrCreate(NoticeTag, { notice, tag, noticeCreatedAt: notice.createdAt });
+            const noticeTag = await getOrCreate(NoticeTag, { notice, tag });
+            noticeTag.noticeCreatedAt = notice.createdAt;
+            await noticeTag.save();
         }),
     );
 }


### PR DESCRIPTION
snuboard-dev 서버와 prod timezone이 달라서 생기는 시간차이로,
notice의 createdAt이 다르면 noticeTag를 새로 만드는 문제
후에 공지사항이 수정되어서 시간이 변경된 경우에서 noticeTag새로 만들게 됨

